### PR TITLE
Fix not showing Min/Max/Restore/Close buttons

### DIFF
--- a/source/CSMS/App.xaml
+++ b/source/CSMS/App.xaml
@@ -3,11 +3,11 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <!-- MahApps.Metro resource dictionaries. Make sure that all file names are Case Sensitive! -->
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Clean/Controls.xaml"/>
-
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
-
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
+
+                <!-- Set the clean style as default style -->
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Clean/Controls.xaml"/>
 
                 <!-- Theme setting -->
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml"/>
@@ -20,7 +20,8 @@
 
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.FlatSlider.xaml"/>
 
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Controls.xaml"/>
+                <!-- This resource dictionary overrides control styles and doesn't work together with the clean style! -->
+                <!-- <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Controls.xaml"/> -->
 
                 <!-- Dragablz -->
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/MahApps.xaml"/>

--- a/source/CSMS/Controls/DragablzTabHostWindow.xaml
+++ b/source/CSMS/Controls/DragablzTabHostWindow.xaml
@@ -17,9 +17,6 @@
         Style="{DynamicResource DefaultWindow}"
         d:DataContext="{d:DesignInstance CSMSControls:DragablzTabHostWindow}"
         >
-    <Controls:MetroWindow.WindowButtonCommands>
-        <Controls:WindowButtonCommands Template="{DynamicResource MahApps.Metro.Templates.WindowButtonCommands.Win10}" />
-    </Controls:MetroWindow.WindowButtonCommands>
     <Grid>
         <dragablz:TabablzControl Focusable="False" Name="TabsContainer" ClosingItemCallback="{Binding CloseItemCommand}">
             <dragablz:TabablzControl.Resources>

--- a/source/CSMS/MainWindow.xaml
+++ b/source/CSMS/MainWindow.xaml
@@ -85,9 +85,6 @@
             </StackPanel>
         </Controls:WindowCommands>
     </Controls:MetroWindow.LeftWindowCommands>
-    <Controls:MetroWindow.WindowButtonCommands>
-        <Controls:WindowButtonCommands Template="{DynamicResource MahApps.Metro.Templates.WindowButtonCommands.Win10}" />
-    </Controls:MetroWindow.WindowButtonCommands>
     <Grid>
         <!-- Is checking license -->
         <Grid Visibility="{Binding IsCheckingLicenseInfo, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">


### PR DESCRIPTION
Fixing the problem with these 2 commits.

- Don't set the VS style in App.xaml because it overrides styles and doesn't work together with the clean style
- The default of the WindowButtonCommands is Win10, no need to set it again
